### PR TITLE
Document methods on TS:Exporter::Meta

### DIFF
--- a/lib/Test/Stream/Exporter.pm
+++ b/lib/Test/Stream/Exporter.pm
@@ -229,6 +229,37 @@ if the package has imported it.
 
 =back
 
+=head1 METHODS
+
+=over 4
+
+=item Test::Stream::Exporter->cleanup
+
+Remove the C<Exporter> utility functions from the package namespace.
+
+=back
+
+=head1 HOOKABLE METHODS
+
+The following methods are not defined by default, but if they are defined, will
+be called before/after importing is done.
+
+=over 4
+
+=item $package->before_import( $caller, \@args)
+
+Will be called C<before> the C<import> happens, with C<@args> being a user
+modifiable C<ARRAYREF> which can be used to filter or augment arguments passed
+to the primary C<export_to> logic.
+
+May return any scalar value, which will be passed to C<after_import> if
+defined.
+
+=item $package->after_import( $caller, $stash, @args )
+
+Will be called C<after> the C<import> happens, with C<$stash> being the return
+value of C<before_import>
+
 =head1 SOURCE
 
 The source code repository for Test::Stream can be found at

--- a/lib/Test/Stream/Exporter/Meta.pm
+++ b/lib/Test/Stream/Exporter/Meta.pm
@@ -150,6 +150,66 @@ experimental phase is over.
 
 L<Test::Stream::Exporter> uses this package to manage exports.
 
+Every package that uses C<Test::Stream::Exporter> has a
+C<Test::Stream::Exporter::Meta> object created for it which contains the
+metadata about the available exports and the kind of export they are.
+
+=head1 METHODS
+
+=over 4
+
+=item Test::Stream::Exporter::Meta->new( $PACKAGE )
+
+Constructs a C<metaobject> for C<$PACKAGE> and returns it. If one already
+exists, it is returned.
+
+=item Test::Stream::Exporter::Meta->get( $PACKAGE )
+
+Returns a C<metaobject> for C<$PACKAGE> if one exists. Returns C<undef> if one
+does not exist.
+
+=item metaobject->add( $SUBNAME )
+
+=item metaobject->add( $SUBNAME => $SUBREF )
+
+Declares an optional export called C<$SUBNAME>. If C<$SUBREF> is not specified,
+then the exported subroutine is automatically retrieved from the C<$PACKAGE>
+associated with the C<metaobject> of the same C<sub> name.
+
+=item metaobject->add_default( $SUBNAME )
+
+=item metaobject->add_default( $SUBNAME => $SUBREF )
+
+Declares a default export called C<$SUBNAME>. Semantics otherwise identical to
+C<< metaobject->add >>
+
+=item metaobject->add_bulk( $SUBNAME, $SUBNAME, ... )
+
+Declare a list of optional exports that are all available as package
+subroutines by the same name.
+
+=item metaobject->add_default_bulk( $SUBNAME, $SUBNAME, ... )
+
+Declare a list of default exports that are all available as package subroutines
+by the same name.
+
+=item metaobject->default()
+
+Returns the list of C<$SUBNAME> values that represent symbols that are exported
+by this exporter which will be exported by default.
+
+=item metaobject->all()
+
+Returns the list of all C<$SUBNAME> values that represent symbols that are
+exported by this exporter.
+
+=item metaobject->exports()
+
+Returns a C<HASHREF> of C<< $SUBNAME => $CODEREF >> values of all avialable
+exports.
+
+=back
+
 =head1 SOURCE
 
 The source code repository for Test::Stream can be found at


### PR DESCRIPTION
A draft work on making Test::Stream::Exporter::Meta more understandable for hackers.