### PR TITLE
Implement "unimport" by renaming "cleanup"

### DIFF
--- a/lib/Test/Stream/Carp.pm
+++ b/lib/Test/Stream/Carp.pm
@@ -9,7 +9,7 @@ export confess => sub { require Carp; goto &Carp::confess };
 export cluck   => sub { require Carp; goto &Carp::cluck };
 export carp    => sub { require Carp; goto &Carp::carp };
 
-Test::Stream::Exporter->cleanup;
+no Test::Stream::Exporter;
 
 1;
 
@@ -75,6 +75,8 @@ F<http://github.com/Test-More/Test-Stream/>.
 =over 4
 
 =item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=item Kent Fredric E<lt>kentnl@cpan.orgE<gt>
 
 =back
 

--- a/lib/Test/Stream/Context.pm
+++ b/lib/Test/Stream/Context.pm
@@ -27,7 +27,7 @@ my $NO_WAIT;
 
 use Test::Stream::Exporter qw/import export_to exports/;
 exports qw/TOP_HUB PUSH_HUB POP_HUB NEW_HUB CULL context/;
-Test::Stream::Exporter->cleanup();
+no Test::Stream::Exporter;
 
 # Set the exit status
 my ($PID, $TID) = ($$, get_tid());
@@ -563,6 +563,8 @@ F<http://github.com/Test-More/Test-Stream/>.
 =over 4
 
 =item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=item Kent Fredric E<lt>kentnl@cpan.orgE<gt>
 
 =back
 

--- a/lib/Test/Stream/Exporter.pm
+++ b/lib/Test/Stream/Exporter.pm
@@ -75,7 +75,7 @@ sub export_to {
     }
 }
 
-sub cleanup {
+sub unimport {
     my $pkg = caller;
     package_purge_sym($pkg, map {(CODE => $_)} qw/export exports default_export default_exports/);
 }
@@ -233,9 +233,15 @@ if the package has imported it.
 
 =over 4
 
-=item Test::Stream::Exporter->cleanup
+=item Test::Stream::Exporter->unimport
 
 Remove the C<Exporter> utility functions from the package namespace.
+
+Recommended usage:
+
+  use Test::Stream::Exporter ...;
+  # declarative code here
+  no Test::Stream::Exporter;
 
 =back
 
@@ -278,6 +284,8 @@ F<http://github.com/Test-More/Test-Stream/>.
 =over 4
 
 =item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=item Kent Fredric E<lt>kentnl@cpan.orgE<gt>
 
 =back
 

--- a/lib/Test/Stream/Exporter/Meta.pm
+++ b/lib/Test/Stream/Exporter/Meta.pm
@@ -229,6 +229,8 @@ F<http://github.com/Test-More/Test-Stream/>.
 
 =item Chad Granum E<lt>exodist@cpan.orgE<gt>
 
+=item Kent Fredric E<lt>kentnl@cpan.orgE<gt>
+
 =back
 
 =head1 COPYRIGHT

--- a/lib/Test/Stream/State.pm
+++ b/lib/Test/Stream/State.pm
@@ -8,7 +8,7 @@ use Test::Stream::HashBase(
     accessors => [qw{count failed ended _passing _plan}],
 );
 
-Test::Stream::Exporter->cleanup;
+no Test::Stream::Exporter;
 
 sub init {
     my $self = shift;
@@ -193,6 +193,8 @@ F<http://github.com/Test-More/Test-Stream/>.
 =over 4
 
 =item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=item Kent Fredric E<lt>kentnl@cpan.orgE<gt>
 
 =back
 

--- a/lib/Test/Stream/TAP.pm
+++ b/lib/Test/Stream/TAP.pm
@@ -14,7 +14,8 @@ sub OUT_TODO() { 2 }
 
 use Test::Stream::Exporter qw/exports export_to/;
 exports qw/OUT_STD OUT_ERR OUT_TODO/;
-Test::Stream::Exporter->cleanup;
+
+no Test::Stream::Exporter;
 
 sub init {
     my $self = shift;
@@ -216,6 +217,8 @@ F<http://github.com/Test-More/Test-Stream/>.
 =over 4
 
 =item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=item Kent Fredric E<lt>kentnl@cpan.orgE<gt>
 
 =back
 

--- a/lib/Test/Stream/Threads.pm
+++ b/lib/Test/Stream/Threads.pm
@@ -29,7 +29,7 @@ BEGIN {
 
 use Test::Stream::Exporter;
 default_exports qw/get_tid USE_THREADS/;
-Test::Stream::Exporter->cleanup;
+no Test::Stream::Exporter;
 
 1;
 
@@ -103,6 +103,8 @@ F<http://github.com/Test-More/Test-Stream/>.
 =over 4
 
 =item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=item Kent Fredric E<lt>kentnl@cpan.orgE<gt>
 
 =back
 

--- a/lib/Test/Stream/Util.pm
+++ b/lib/Test/Stream/Util.pm
@@ -8,7 +8,7 @@ use Test::Stream::Carp qw/croak/;
 
 exports qw{ try protect spoof };
 
-Test::Stream::Exporter->cleanup();
+no Test::Stream::Exporter;
 
 sub _manual_protect(&) {
     my $code = shift;
@@ -191,6 +191,8 @@ F<http://github.com/Test-More/Test-Stream/>.
 =over 4
 
 =item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=item Kent Fredric E<lt>kentnl@cpan.orgE<gt>
 
 =back
 

--- a/t/Test-Stream-Exporter.t
+++ b/t/Test-Stream-Exporter.t
@@ -21,12 +21,16 @@ use Test::More;
 
     export '$export' => \$export;
 
-    Test::Stream::Exporter->cleanup;
+    no Test::Stream::Exporter;
+
+    sub export {
+      die "This is a custom sub";
+    }
 
     is($export,            'here', "still have an \$export var");
     is($main::export::xxx, 'here', "still have an \$export::* var");
 
-    ok(!__PACKAGE__->can($_), "removed $_\()") for qw/export default_export exports default_exports/;
+    ok(!__PACKAGE__->can($_), "removed $_\()") for qw/default_export exports default_exports/;
 }
 
 My::Exporter->import( '!x' );
@@ -75,5 +79,14 @@ is_deeply(
     },
     "Exports are what we expect"
 );
+
+my ($error, $return);
+{
+  local $@;
+  $return = eval { My::Exporter->export; 1 };
+  $error = $@;
+}
+ok( !$return, 'Custom fatal export sub died as expected');
+like( $error, qr/This is a custom sub/, 'Custom fatal export sub died as expected with the right message');
 
 done_testing;


### PR DESCRIPTION
This allows the declarative symbols to be purged during BEGIN phase
while still allowing them to be consumed by declarative syntax.

This allows people to declare methods with the same name as declarative
symbols without having any kind of symbol conflict.

Note: The reason for 
```perl
 Test::Stream::Exporter->cleanup;
```

In Test::Stream::State seems odd when there is no import of that class.

This avoided being a bug by the previous 2 modules loading it guaranteeing the module was loaded first.

However, `no` also makes sure the module getting unimported is in fact, loaded, so it would avoid bugs if that was intentional.