### PR TITLE
Context: Init hook

### DIFF
--- a/t/Test-Stream-Context.t
+++ b/t/Test-Stream-Context.t
@@ -133,6 +133,21 @@ my $dbg2 = tool()->debug;
 is($dbg1->todo, 'Here be dragons', "Got todo in context created with todo in place");
 is($dbg2->todo, undef, "no todo in context created after todo was removed");
 
+Test::Stream::Context->clear;
+
+my $called = 0;
+$ctx = context(level => -1, init => sub { $called++ });
+is($called, 1, "Called context init hook");
+
+my $ctx2 = context(level => -1, init => sub { $called++ });
+is($called, 1, "Did not call init hook again");
+
+$ctx = undef;
+$ctx2 = undef;
+
+$ctx = context(level => -1, init => sub { $called++ });
+is($called, 2, "Called context init hook again");
+
 done_testing;
 
 # This is necessary cause we have a root hub that will set the exit code to 255


### PR DESCRIPTION
 * Change context to take named arguments.
 * Allow init callback

init callback is a callback that will be called ONLY if the call to
context is the one that created the context, it will NOT fire if the
context already exists.

This will be needed for Test-Builder backcompat to set the TODO
variable.