### PR TITLE
Ok-Diag - do not use diag objects inside ok

### DIFF
--- a/lib/Test/Stream/DebugInfo.pm
+++ b/lib/Test/Stream/DebugInfo.pm
@@ -46,6 +46,12 @@ sub file    { $_[0]->{+FRAME}->[1] }
 sub line    { $_[0]->{+FRAME}->[2] }
 sub subname { $_[0]->{+FRAME}->[3] }
 
+sub no_fail {
+    my $self = shift;
+    return defined($self->{+TODO})
+        || defined($self->{+SKIP});
+}
+
 1;
 
 __END__

--- a/lib/Test/Stream/Event/Diag.pm
+++ b/lib/Test/Stream/Event/Diag.pm
@@ -3,11 +3,10 @@ use strict;
 use warnings;
 
 use Test::Stream::Event(
-    accessors => [qw/message linked/],
+    accessors => [qw/message/],
 );
 
 use Carp qw/confess/;
-use Scalar::Util qw/weaken/;
 
 use Test::Stream::TAP qw/OUT_TODO OUT_ERR/;
 
@@ -19,15 +18,6 @@ sub init {
     else {
         $_[0]->{+MESSAGE} = 'undef';
     }
-    weaken($_[0]->{+LINKED}) if $_[0]->{+LINKED};
-}
-
-sub link {
-    my $self = shift;
-    my ($to) = @_;
-    confess "Already linked!" if $self->{+LINKED};
-    $self->{+LINKED} = $to;
-    weaken($self->{+LINKED});
 }
 
 sub to_tap {
@@ -88,20 +78,6 @@ Diagnostics messages, typically rendered to STDERR.
 =item $diag->message
 
 The message for the diag.
-
-=item $diag->linked
-
-The Ok event the diag is linked to, if it is.
-
-=back
-
-=head1 METHODS
-
-=over 4
-
-=item $diag->link($ok);
-
-Link the diag to an OK event.
 
 =back
 

--- a/t/Test-Stream-Event-Diag.t
+++ b/t/Test-Stream-Event-Diag.t
@@ -39,22 +39,4 @@ is_deeply(
     "All lines have '#'"
 );
 
-my $link = {};
-$diag = Test::Stream::Event::Diag->new(
-    debug => Test::Stream::DebugInfo->new(frame => [__PACKAGE__, __FILE__, __LINE__]),
-    message => 'foo',
-    linked => $link,
-);
-$link->{link} = $diag;
-
-is($diag->linked, $link, "got link");
-$link = 0;
-ok(!$diag->linked, "link is weak ref (avoid cycles)");
-
-$link = {link => $diag};
-$diag->link($link);
-is($diag->linked, $link, "got link");
-$link = 0;
-ok(!$diag->linked, "link is weak ref (avoid cycles)");
-
 done_testing;


### PR DESCRIPTION
Use of a Diag object inside an OK was an unnecessary "shortcut" that
complicated things needlessly.

The diag messages themselves were set to happen automatically and
directly mimick Test-Mores. I am making them non-automatic to the event
itself, but still automatic via context. This will allow Test-More to
use back-compat diags, but allow Test-Stream to move forward with new
diagnostics styles.