### PR TITLE
make 'is' more strict, always use string compares for non-refs

### DIFF
--- a/lib/Test/Stream/Plugin/Compare.pm
+++ b/lib/Test/Stream/Plugin/Compare.pm
@@ -399,7 +399,12 @@ sub convert {
     return Test::Stream::Compare::Ref->new(input => $thing)
         if $type;
 
-    return Test::Stream::Compare::Value->new(input => $thing);
+    # Like() will guess between a number and a string
+    return Test::Stream::Compare::Value->new(input => $thing)
+        unless $strict;
+
+    # is() will assume string and use 'eq'
+    return Test::Stream::Compare::String->new(input => $thing);
 }
 
 1;
@@ -521,6 +526,9 @@ work as well, however there are problems if your reference contains a cyle and
 refers back to itself at some point, if this happens an exception will be
 thrown to break an otherwise infinite recursion.
 
+B<Note>: Non-reference values will be compared as strings using C<eq>, that
+means '2.0' and '2' will match.
+
 =item like($got, $expect)
 
 =item like($got, $expect, $name)
@@ -550,6 +558,9 @@ This works for both deep and shallow structures. For instance you can use this
 to compare 2 strings:
 
     like('foo bar', qr/^foo/, "string matches the pattern");
+
+B<Note>: C<like()> is essentially a relaxed form of C<is()>, it will guess if a
+non-ref value is a number or a string and compare accordingly.
 
 =back
 

--- a/t/modules/Plugin/Compare.t
+++ b/t/modules/Plugin/Compare.t
@@ -70,7 +70,7 @@ tests is => sub {
                     '+--------+-----+---------+------------------+',
                     '| PATH   | GOT | OP      | CHECK            |',
                     '+--------+-----+---------+------------------+',
-                    '| [0]{a} | 2   | ==      | 1                |',
+                    '| [0]{a} | 2   | eq      | 1                |',
                     '| [0]{b} | 3   | !exists | <DOES NOT EXIST> |',
                     '+--------+-----+---------+------------------+',
                     'diag',
@@ -246,11 +246,11 @@ tests convert => sub {
     *strict_convert = $CLASS->can('strict_convert');
     *relaxed_convert = $CLASS->can('relaxed_convert');
     my @sets = (
-        ['a',   'Value', 'Value'],
-        [undef, 'Value', 'Value'],
-        ['',    'Value', 'Value'],
-        [1,     'Value', 'Value'],
-        [0,     'Value', 'Value'],
+        ['a',   'String', 'Value'],
+        [undef, 'String', 'Value'],
+        ['',    'String', 'Value'],
+        [1,     'String', 'Value'],
+        [0,     'String', 'Value'],
         [[],    'Array', 'Array'],
         [{},    'Hash',  'Hash'],
         [qr/x/, 'Regex',   'Pattern'],
@@ -266,7 +266,7 @@ tests convert => sub {
 
         [
             bless({expect => 'a'}, 'Test::Stream::Compare::Wildcard'),
-            'Value',
+            'String',
             'Value',
         ],
     );


### PR DESCRIPTION
This addresses concerns about the 'is()' implementation of Test::Stream::Plugin::Compare guessing if a scalar is a number or a string.