### PR TITLE
Added 'Subtest: ' to subtest_buffered's test name.

### DIFF
--- a/lib/Test/Stream/Plugin/Subtest.pm
+++ b/lib/Test/Stream/Plugin/Subtest.pm
@@ -42,7 +42,7 @@ sub subtest_streamed {
 sub subtest_buffered {
     my ($name, $code, @args) = @_;
     my $ctx = context();
-    my $pass = _subtest($name, $code, 1, @args);
+    my $pass = _subtest("Subtest: $name", $code, 1, @args);
     $ctx->release;
     return $pass;
 }

--- a/t/modules/Plugin/Spec/reporting.t
+++ b/t/modules/Plugin/Spec/reporting.t
@@ -79,11 +79,11 @@ like(
         # Failure in the inner block
         event Subtest => sub {
             call pass => 0;
-            call diag => [ qr{Failed test 'outer'} ];
+            call diag => [ qr{Failed test 'Subtest: outer'} ];
             call subevents => array {
                 event Subtest => sub {
                     call pass => 0;
-                    call diag => [ qr{Failed test 'inner'} ];
+                    call diag => [ qr{Failed test 'Subtest: inner'} ];
                     call subevents => array {
                         event Ok => { pass => 0 };
                     };
@@ -94,11 +94,11 @@ like(
 
         event Subtest => sub {
             call pass => 0;
-            call diag => [ qr{Failed test 'outer'}s ];
+            call diag => [ qr{Failed test 'Subtest: outer'}s ];
             call subevents => array {
                 event Subtest => sub {
                     call pass => 0;
-                    call diag => [ qr{Failed test 'inner'} ];
+                    call diag => [ qr{Failed test 'Subtest: inner'} ];
                     call subevents => array {
                         event Exception => { error => qr{xxx} };
                     };
@@ -109,11 +109,11 @@ like(
 
         event Subtest => sub {
             call pass => 0;
-            call diag => [ qr{Failed test 'outer'}s ];
+            call diag => [ qr{Failed test 'Subtest: outer'}s ];
             call subevents => array {
                 event Subtest => sub {
                     call pass => 0;
-                    call diag => [ qr{Failed test 'inner'} ];
+                    call diag => [ qr{Failed test 'Subtest: inner'} ];
                     call subevents => array {
                         event Ok => { name => 'a', pass => 0 };
                         event Ok => { name => 'b', pass => 0 };
@@ -133,11 +133,11 @@ like(
 
         event Subtest => sub {
             call pass => 0;
-            call diag => [ qr{Failed test 'outer'}s ];
+            call diag => [ qr{Failed test 'Subtest: outer'}s ];
             call subevents => array {
                 event Subtest => sub {
                     call pass => 0;
-                    call diag => [ qr{Failed test 'inner'} ];
+                    call diag => [ qr{Failed test 'Subtest: inner'} ];
                     call subevents => array {
                         event Exception => { error => qr{xxx} };
                         event Ok => { name => 'b', pass => 0 };
@@ -157,11 +157,11 @@ like(
 
         event Subtest => sub {
             call pass => 0;
-            call diag => [ qr{Failed test 'outer'}s ];
+            call diag => [ qr{Failed test 'Subtest: outer'}s ];
             call subevents => array {
                 event Subtest => sub {
                     call pass => 0;
-                    call diag => [ qr{Failed test 'inner'} ];
+                    call diag => [ qr{Failed test 'Subtest: inner'} ];
                     call subevents => array {
                         event Ok => {
                             pass => 0,

--- a/t/modules/Plugin/Subtest.t
+++ b/t/modules/Plugin/Subtest.t
@@ -65,7 +65,7 @@ like(
             field subevents => array {
                 event Subtest => sub {
                     field pass => 1;
-                    field name => 'bar';
+                    field name => 'Subtest: bar';
                     field subevents => array {
                         event Ok => sub {
                             field name => 'pass';
@@ -257,7 +257,7 @@ like(
             prop file => __FILE__;
             prop line => $lines[0];
             field pass => 1;
-            field name => 'foo';
+            field name => 'Subtest: foo';
             field subevents => array {
                 event Ok => sub {
                     prop file => __FILE__;
@@ -285,7 +285,7 @@ like(
             prop file => __FILE__;
             prop line => $lines[0];
             field pass => 0;
-            field name => 'foo';
+            field name => 'Subtest: foo';
             field subevents => array {
                 event Ok => sub {
                     prop file => __FILE__;
@@ -314,7 +314,7 @@ like(
             prop file => __FILE__;
             prop line => $lines[0];
             field pass => 1;
-            field name => 'foo';
+            field name => 'Subtest: foo';
             field subevents => array {
                 event Ok => sub {
                     prop file => __FILE__;
@@ -345,7 +345,7 @@ like(
             prop file => __FILE__;
             prop line => $lines[0];
             field pass => 1;
-            field name => 'foo';
+            field name => 'Subtest: foo';
             field subevents => array {
                 event Plan => { max => 1 };
                 event Ok => sub {
@@ -376,7 +376,7 @@ like(
             prop file => __FILE__;
             prop line => $lines[0];
             field pass => 1;
-            field name => 'foo';
+            field name => 'Subtest: foo';
             field subevents => array {
                 event Plan => { directive => 'SKIP', reason => 'bleh' };
                 end;

--- a/t/modules/Workflow/Task.t
+++ b/t/modules/Workflow/Task.t
@@ -203,7 +203,7 @@ $unit->primary(sub { 1 });
     $ran = 0;
     is(
         intercept { $one->run },
-        array { event Subtest => { pass => 1, name => 'bob' } },
+        array { event Subtest => { pass => 1, name => 'Subtest: bob' } },
         "Got subtest event (pass)"
     );
     is($ran, 1, "ran the iteration");
@@ -213,7 +213,7 @@ $unit->primary(sub { 1 });
     $ran = 0;
     is(
         intercept { $one->run },
-        array { event Subtest => { pass => 0, name => 'bob' } },
+        array { event Subtest => { pass => 0, name => 'Subtest: bob' } },
         "Got subtest event (fail)"
     );
     is($ran, 1, "ran the iteration");


### PR DESCRIPTION
According to the pod of `Test::Stream::Plugin::Subtest`, `subtest_buffered` the beginning of the test name "Subtest:" has been adding and not actually added.

```
from pod of Test::Stream::Plugin::Subtest

  BUFFERED
        # You can use either of the next 2 lines, they are both equivilent
        use Test::Stream Subtest => ['buffered'];
        use Test::Stream::Plugin::Subtest qw/buffered/;

        subtest my_test => sub {
            ok(1, "subtest event A");
            ok(1, "subtest event B");
        };

    This will produce output like this:

        ok 1 - Subtest: my_test {
            ok 1 - subtest event A
            ok 2 - subtest event B
            1..2
        }
```