### PR TITLE
pod: spelling fixes

### DIFF
--- a/README
+++ b/README
@@ -63,13 +63,13 @@ IMPORTANT NOTE
     Future Proofing. If we decide in the future that a specific plugin or
     tool is harmful we would like to be able to remove it. Making a tool
     part of the default set will effectively make it unremovable as doing so
-    would break compatability. To solve this problem we have the 'Core#'
+    would break compatibility. To solve this problem we have the 'Core#'
     bundle system.
 
     'V1' is the first bundle, and the recommended one for now. If the future
     tells us that parts of 'V1' are harmful, or that we need more than what
     is currently provided, we can release 'V2'. 'V1' will not be changed in
-    a backwords incompatible way, so nothing breaks, but everyone else can
+    a backwards incompatible way, so nothing breaks, but everyone else can
     move on and start using 'V2' in new code.
 
     The number following the 'V' prefix should correspond to a major version
@@ -106,7 +106,7 @@ PLUGINS, BUNDLES, AND OPTIONS
     '-V1',
         The "-" prefix indicates that the specified item is a bundle.
         Bundles live in the "Test::Stream::Bundle::" namespace. Each bundle
-        is an independant module. You can specify any number of bundles, or
+        is an independent module. You can specify any number of bundles, or
         none at all.
 
     ':Project'
@@ -165,7 +165,7 @@ PLUGINS, BUNDLES, AND OPTIONS
         options of their own.
 
         To define an option in your subclass simply add a "sub opt_NAME()"
-        method. The method will recieve several arguments:
+        method. The method will receive several arguments:
 
             sub opt_foo {
                 my $class = shift;
@@ -226,7 +226,7 @@ PLUGINS, BUNDLES, AND OPTIONS
 
     Test::Stream does not recreate this wild west approach to testing tools
     and bundles. Test::Stream recognises the benefits of bundles, but
-    provides a much more sane approach. Bundles and Tools are kept seperate,
+    provides a much more sane approach. Bundles and Tools are kept separate,
     this way you can always use tools without being forced to adopt the
     authors ideal bundle.
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Explanation:
     by the loader. Loaders that subclass Test::Stream can add options of their own.
 
     To define an option in your subclass simply add a `sub opt_NAME()` method. The
-    method will recieve several arguments:
+    method will receive several arguments:
 
         sub opt_foo {
             my $class = shift;
@@ -246,7 +246,7 @@ want to load.
 
 [Test::Stream](https://metacpan.org/pod/Test::Stream) does not recreate this wild west approach to testing tools and
 bundles. [Test::Stream](https://metacpan.org/pod/Test::Stream) recognises the benefits of bundles, but provides a
-much more sane approach. Bundles and Tools are kept seperate, this way you can
+much more sane approach. Bundles and Tools are kept separate, this way you can
 always use tools without being forced to adopt the authors ideal bundle.
 
 # ENVIRONMENT VARIABLES

--- a/lib/Test/Stream.pm
+++ b/lib/Test/Stream.pm
@@ -391,7 +391,7 @@ Uncapitalized options without a C<+>, C<->, or C<:> prefix are reserved for use
 by the loader. Loaders that subclass Test::Stream can add options of their own.
 
 To define an option in your subclass simply add a C<sub opt_NAME()> method. The
-method will recieve several arguments:
+method will receive several arguments:
 
     sub opt_foo {
         my $class = shift;
@@ -471,7 +471,7 @@ want to load.
 
 L<Test::Stream> does not recreate this wild west approach to testing tools and
 bundles. L<Test::Stream> recognises the benefits of bundles, but provides a
-much more sane approach. Bundles and Tools are kept seperate, this way you can
+much more sane approach. Bundles and Tools are kept separate, this way you can
 always use tools without being forced to adopt the authors ideal bundle.
 
 =head1 ENVIRONMENT VARIABLES

--- a/lib/Test/Stream/Compare.pm
+++ b/lib/Test/Stream/Compare.pm
@@ -197,7 +197,7 @@ for several comparison classes that allow for deep structure comparisons.
         my $params = @_;
 
         # Always check if $got even exists, this will be false if no value at
-        # all was recieved. (as opposed to a $got of 'undef' or '0' which are
+        # all was received. (as opposed to a $got of 'undef' or '0' which are
         # valid meaning this field will be true).
         return 0 unless $params{exists};
 
@@ -293,7 +293,7 @@ structure.
 
 =item $op = $check->operator($got)
 
-Returns the operator that was used to compare the check with the recieved data
+Returns the operator that was used to compare the check with the received data
 in C<$got>. If there was no value for got then there will be no arguments,
 undef will only be an argument if undef was seen in C<$got>, this is how you
 can tell the difference between a missing value and an undefined one.

--- a/lib/Test/Stream/Compare/Array.pm
+++ b/lib/Test/Stream/Compare/Array.pm
@@ -185,7 +185,7 @@ reference to that array.
 
 Set this to true if you would like to fail when the array being validated has
 more items than the check. That is if you check indexes 0-3, but the array
-recieved has values for indexes 0-4, it will fail and list that last item in
+received has values for indexes 0-4, it will fail and list that last item in
 the array as unexpected. If this is false then it is assumed you do not care
 about extra items.
 
@@ -230,7 +230,7 @@ index after the last is used.
 
 =item $arr->add_filter(sub { ... })
 
-Add a filter sub. The filter recieves all remaining values of the array being
+Add a filter sub. The filter receives all remaining values of the array being
 checked, and should return the values that should still be checked. The filter
 will be run between the last item added and the next item added.
 

--- a/lib/Test/Stream/Compare/Custom.pm
+++ b/lib/Test/Stream/Compare/Custom.pm
@@ -55,7 +55,7 @@ Test::Stream::Compare::Custom - Custom field check for comparisons.
 
 Sometimes you want to do something complicated or unusual when validating a
 field nested inside a deep data structure. You could pull it out of the
-structure and test it seperately, or you can use this to embed the check. This
+structure and test it separately, or you can use this to embed the check. This
 provides a way for you to write custom checks for fields in deep comparisons.
 
 =head1 SYNOPSIS

--- a/lib/Test/Stream/Context.pm
+++ b/lib/Test/Stream/Context.pm
@@ -683,7 +683,7 @@ These are B<GLOBAL> hooks into the context tools. Every sub added via ON_INIT
 will be called every single time a new context is initialized. Every sub added
 via ON_RELEASE will be called every single time a context is released.
 
-Subs will recieve exactly 1 argument, that is the context itself. You should
+Subs will receive exactly 1 argument, that is the context itself. You should
 not call C<release> on the context within your callback.
 
 =back

--- a/lib/Test/Stream/DeferredTests.pm
+++ b/lib/Test/Stream/DeferredTests.pm
@@ -106,7 +106,7 @@ are defined.
 =item def function => @args;
 
 This will store the function name, and the arguments to be run later. Note that
-each package has a seperate store of tests to run.
+each package has a separate store of tests to run.
 
 =item do_def()
 

--- a/lib/Test/Stream/Delta.pm
+++ b/lib/Test/Stream/Delta.pm
@@ -380,9 +380,9 @@ C<METHOD>.
 
 =item $delta->set_got($val)
 
-Deltas are produced by comparing a recieved data structure 'got' against a
+Deltas are produced by comparing a received data structure 'got' against a
 check data structure 'check'. The 'got' attribute contains the value that was
-recieved for comparison.
+received for comparison.
 
 =item $check = $delta->chk
 
@@ -392,7 +392,7 @@ recieved for comparison.
 
 =item $delta->set_check($check)
 
-Deltas are produced by comparing a recieved data structure 'got' against a
+Deltas are produced by comparing a received data structure 'got' against a
 check data structure 'check'. The 'check' attribute contains the value that was
 expected in the comparison.
 
@@ -428,7 +428,7 @@ an exception being thrown.
 
 =item $string = $delta->render_got
 
-Renders the string that should be used in a table to represent the recieved
+Renders the string that should be used in a table to represent the received
 value in a comparison.
 
 =item $string = $delta->render_check

--- a/lib/Test/Stream/Manual/FromTestBuilder.pod
+++ b/lib/Test/Stream/Manual/FromTestBuilder.pod
@@ -264,7 +264,7 @@ These are no longer around for you to use.
 =item require_ok
 
 Errors loading modules cause the test to die anyway, so just load them, if they
-do not work the test will fail. Making a seperate API for this is a wasted
+do not work the test will fail. Making a separate API for this is a wasted
 effort. Also doing this requires the functions to guess if you provided a
 module name, or filename, and then munging the input to figure out what
 actually needs to be loaded.

--- a/lib/Test/Stream/Plugin/Compare.pm
+++ b/lib/Test/Stream/Plugin/Compare.pm
@@ -692,7 +692,7 @@ you can specify a name and operator that are used in diagnostics, they are also
 provided to the sub itself as named parameters.
 
 Check the value using this sub. The sub gets the value in C<$_>, as well it
-recieved the value and several other items as named parameters.
+received the value and several other items as named parameters.
 
     my $check = validator(sub {
         my %params = @_;

--- a/lib/Test/Stream/Plugin/Defer.pm
+++ b/lib/Test/Stream/Plugin/Defer.pm
@@ -46,7 +46,7 @@ This is the plugin form of L<Test::Stream::DeferredTests>.
 =item def function => @args;
 
 This will store the function name, and the arguments to be run later. Note that
-each package has a seperate store of tests to run.
+each package has a separate store of tests to run.
 
 =item do_def()
 


### PR DESCRIPTION
Thanks for the work on this module.

This commit fixes some spelling errors in the documentation.