### PR TITLE
Deprecate mungers, add filters

### DIFF
--- a/lib/Test/Stream/Manual/Tooling.pod
+++ b/lib/Test/Stream/Manual/Tooling.pod
@@ -127,9 +127,8 @@ tracking state. Hubs have an instance of an L<Test::Stream::State> object. When
 an event is processed by a hub the state will be updated accordingly.
 
 The second job of a hub is to make sure events get to the right place.
-Typically this means processing the event through any hooks or filters called
-'mungers', then handing them off to the formatter, then finally running them
-through and 'listeners'.
+Typically this means processing the event through any 'filters', then handing
+them off to the formatter, then finally running them through 'listeners'.
 
 When IPC is active the hub will use the IPC driver (See L<Test::Stream::IPC>)
 to send events to the correct process or thread. 

--- a/t/modules/Hub.t
+++ b/t/modules/Hub.t
@@ -1,4 +1,4 @@
-use Test::Stream -V1, -SpecTester;
+use Test::Stream -V1, -SpecTester, Compare => [qw/is like match/];
 use Test::Stream::Capabilities qw/CAN_FORK CAN_THREAD CAN_REALLY_FORK/;
 
 {
@@ -252,6 +252,8 @@ tests metadata => sub {
 };
 
 tests munge => sub {
+    my @warnings;
+    local $SIG{__WARN__} = sub { push @warnings => @_ };
     my $hub = Test::Stream::Hub->new();
 
     my @events;
@@ -317,6 +319,88 @@ tests munge => sub {
         dies { $hub->munge('xxx') },
         qr/munge only takes coderefs for arguments, got 'xxx'/,
         "munge takes a coderef"
+    );
+
+    delete $SIG{__WARN__};
+    is(
+        \@warnings,
+        [
+            match qr/use of mungers is deprecated, look at filters instead\. mungers will be removed in the near future\./,
+            match qr/use of mungers is deprecated, look at filters instead\. mungers will be removed in the near future\./,
+            match qr/use of mungers is deprecated, look at filters instead\. mungers will be removed in the near future\./,
+            match qr/use of mungers is deprecated, look at filters instead\. mungers will be removed in the near future\./,
+        ],
+        "Got the warnings"
+    );
+};
+
+tests filter => sub {
+    my $hub = Test::Stream::Hub->new();
+
+    my @events;
+    my $it = $hub->filter(sub {
+        my ($h, $e) = @_;
+        is($h, $hub, "got hub");
+        push @events => $e;
+        return $e;
+    });
+
+    my $count;
+    my $it2 = $hub->filter(sub { $count++; $_[1] });
+
+    my $ok1 = Test::Stream::Event::Ok->new(
+        pass => 1,
+        name => 'foo',
+        debug => Test::Stream::DebugInfo->new(
+            frame => [ __PACKAGE__, __FILE__, __LINE__ ],
+        ),
+    );
+
+    my $ok2 = Test::Stream::Event::Ok->new(
+        pass => 0,
+        name => 'bar',
+        debug => Test::Stream::DebugInfo->new(
+            frame => [ __PACKAGE__, __FILE__, __LINE__ ],
+        ),
+    );
+
+    my $ok3 = Test::Stream::Event::Ok->new(
+        pass => 1,
+        name => 'baz',
+        debug => Test::Stream::DebugInfo->new(
+            frame => [ __PACKAGE__, __FILE__, __LINE__ ],
+        ),
+    );
+
+    $hub->send($ok1);
+    $hub->send($ok2);
+
+    $hub->unfilter($it);
+
+    $hub->send($ok3);
+
+    is(\@events, [$ok1, $ok2], "got events");
+    is($count, 3, "got all events, even after other filter was removed");
+
+    $hub = Test::Stream::Hub->new();
+    @events = ();
+
+    $hub->filter(sub { undef });
+    $hub->listen(sub {
+        my ($hub, $e) = @_;
+        push @events => $e;
+    });
+
+    $hub->send($ok1);
+    $hub->send($ok2);
+    $hub->send($ok3);
+
+    ok(!@events, "Blocked events");
+
+    like(
+        dies { $hub->filter('xxx') },
+        qr/filter only takes coderefs for arguments, got 'xxx'/,
+        "filter takes a coderef"
     );
 };
 

--- a/t/modules/Sync.t
+++ b/t/modules/Sync.t
@@ -329,7 +329,7 @@ is(
         delete $INC{'Test/Stream/IPC.pm'};
         $reset->();
         my @events;
-        $sync->stack->top->munge(sub { push @events => $_[1]; $_[1] = undef });
+        $sync->stack->top->filter(sub { push @events => $_[1]; undef });
         $sync->stack->new_hub;
         local $? = 0;
         $sync->_set_exit;
@@ -340,7 +340,7 @@ is(
     {
         $reset->();
         my @events;
-        $sync->stack->top->munge(sub { push @events => $_[1]; $_[1] = undef });
+        $sync->stack->top->filter(sub { push @events => $_[1]; undef });
         $sync->stack->new_hub;
         def ok => ($sync->stack->top->ipc, "Have IPC");
         $sync->stack->new_hub;


### PR DESCRIPTION
 * Deprecates mungers with documentation and a warning.
 * Adds filters to replace them
 * Replaces use of mungers in tests