### PR TITLE
Deprecate HashBase 'base' arg. Deprecate Event import

### DIFF
--- a/lib/Test/Stream/Compare.pm
+++ b/lib/Test/Stream/Compare.pm
@@ -177,11 +177,8 @@ for several comparison classes that allow for deep structure comparisons.
     use strict;
     use warnings;
 
-    use Test::Stream::Compare;
-    use Test::Stream::HashBase(
-        base => 'Test::Stream::Compare',
-        accessors => [qw/stuff/],
-    );
+    use base 'Test::Stream::Compare';
+    use Test::Stream::HashBase accessors => [qw/stuff/];
 
     sub name { 'STUFF' }
 

--- a/lib/Test/Stream/Compare/Array.pm
+++ b/lib/Test/Stream/Compare/Array.pm
@@ -2,11 +2,8 @@ package Test::Stream::Compare::Array;
 use strict;
 use warnings;
 
-use Test::Stream::Compare();
-use Test::Stream::HashBase(
-    base => 'Test::Stream::Compare',
-    accessors => [qw/inref ending items order/],
-);
+use base 'Test::Stream::Compare';
+use Test::Stream::HashBase accessors => [qw/inref ending items order/];
 
 use Carp qw/croak confess/;
 use Scalar::Util qw/reftype looks_like_number/;

--- a/lib/Test/Stream/Compare/Custom.pm
+++ b/lib/Test/Stream/Compare/Custom.pm
@@ -2,11 +2,8 @@ package Test::Stream::Compare::Custom;
 use strict;
 use warnings;
 
-use Test::Stream::Compare();
-use Test::Stream::HashBase(
-    base => 'Test::Stream::Compare',
-    accessors => [qw/code name operator/],
-);
+use base 'Test::Stream::Compare';
+use Test::Stream::HashBase accessors => [qw/code name operator/];
 
 use Carp qw/croak/;
 

--- a/lib/Test/Stream/Compare/Event.pm
+++ b/lib/Test/Stream/Compare/Event.pm
@@ -4,12 +4,10 @@ use warnings;
 
 use Scalar::Util qw/blessed/;
 
-use Test::Stream::Compare::Object();
 use Test::Stream::Compare::EventMeta();
-use Test::Stream::HashBase(
-    base => 'Test::Stream::Compare::Object',
-    accessors => [qw/etype/],
-);
+
+use base 'Test::Stream::Compare::Object';
+use Test::Stream::HashBase accessors => [qw/etype/];
 
 sub name {
     my $self = shift;

--- a/lib/Test/Stream/Compare/EventMeta.pm
+++ b/lib/Test/Stream/Compare/EventMeta.pm
@@ -2,10 +2,8 @@ package Test::Stream::Compare::EventMeta;
 use strict;
 use warnings;
 
-use Test::Stream::Compare::Meta();
-use Test::Stream::HashBase(
-    base => 'Test::Stream::Compare::Meta',
-);
+use base 'Test::Stream::Compare::Meta';
+use Test::Stream::HashBase;
 
 sub get_prop_file    { $_[1]->debug->file }
 sub get_prop_line    { $_[1]->debug->line }

--- a/lib/Test/Stream/Compare/Hash.pm
+++ b/lib/Test/Stream/Compare/Hash.pm
@@ -2,11 +2,8 @@ package Test::Stream::Compare::Hash;
 use strict;
 use warnings;
 
-use Test::Stream::Compare();
-use Test::Stream::HashBase(
-    base => 'Test::Stream::Compare',
-    accessors => [qw/inref ending items order/],
-);
+use base 'Test::Stream::Compare';
+use Test::Stream::HashBase accessors => [qw/inref ending items order/];
 
 use Carp qw/croak confess/;
 use Scalar::Util qw/reftype/;

--- a/lib/Test/Stream/Compare/Meta.pm
+++ b/lib/Test/Stream/Compare/Meta.pm
@@ -4,11 +4,8 @@ use warnings;
 
 use Test::Stream::Delta();
 
-use Test::Stream::Compare();
-use Test::Stream::HashBase(
-    base => 'Test::Stream::Compare',
-    accessors => [qw/items/],
-);
+use base 'Test::Stream::Compare';
+use Test::Stream::HashBase accessors => [qw/items/];
 
 use Carp qw/croak confess/;
 use Scalar::Util qw/reftype blessed/;

--- a/lib/Test/Stream/Compare/Number.pm
+++ b/lib/Test/Stream/Compare/Number.pm
@@ -4,11 +4,8 @@ use warnings;
 
 use Carp qw/confess/;
 
-use Test::Stream::Compare();
-use Test::Stream::HashBase(
-    base => 'Test::Stream::Compare',
-    accessors => [qw/input negate/],
-);
+use base 'Test::Stream::Compare';
+use Test::Stream::HashBase accessors => [qw/input negate/];
 
 sub init {
     my $self = shift;

--- a/lib/Test/Stream/Compare/Object.pm
+++ b/lib/Test/Stream/Compare/Object.pm
@@ -4,12 +4,10 @@ use warnings;
 
 use Test::Stream::Util qw/try/;
 
-use Test::Stream::Compare();
 use Test::Stream::Compare::Meta();
-use Test::Stream::HashBase(
-    base => 'Test::Stream::Compare',
-    accessors => [qw/calls meta refcheck ending/],
-);
+
+use base 'Test::Stream::Compare';
+use Test::Stream::HashBase accessors => [qw/calls meta refcheck ending/];
 
 use Carp qw/croak confess/;
 use Scalar::Util qw/reftype blessed/;

--- a/lib/Test/Stream/Compare/Pattern.pm
+++ b/lib/Test/Stream/Compare/Pattern.pm
@@ -2,11 +2,8 @@ package Test::Stream::Compare::Pattern;
 use strict;
 use warnings;
 
-use Test::Stream::Compare();
-use Test::Stream::HashBase(
-    base => 'Test::Stream::Compare',
-    accessors => [qw/pattern negate/],
-);
+use base 'Test::Stream::Compare';
+use Test::Stream::HashBase accessors => [qw/pattern negate/];
 
 use Carp qw/croak/;
 

--- a/lib/Test/Stream/Compare/Ref.pm
+++ b/lib/Test/Stream/Compare/Ref.pm
@@ -2,11 +2,8 @@ package Test::Stream::Compare::Ref;
 use strict;
 use warnings;
 
-use Test::Stream::Compare();
-use Test::Stream::HashBase(
-    base => 'Test::Stream::Compare',
-    accessors => [qw/input/],
-);
+use base 'Test::Stream::Compare';
+use Test::Stream::HashBase accessors => [qw/input/];
 
 use Test::Stream::Util qw/render_ref rtype/;
 use Scalar::Util qw/reftype refaddr/;

--- a/lib/Test/Stream/Compare/Regex.pm
+++ b/lib/Test/Stream/Compare/Regex.pm
@@ -2,11 +2,8 @@ package Test::Stream::Compare::Regex;
 use strict;
 use warnings;
 
-use Test::Stream::Compare();
-use Test::Stream::HashBase(
-    base => 'Test::Stream::Compare',
-    accessors => [qw/input/],
-);
+use base 'Test::Stream::Compare';
+use Test::Stream::HashBase accessors => [qw/input/];
 
 use Test::Stream::Util qw/render_ref rtype/;
 use Scalar::Util qw/reftype refaddr/;

--- a/lib/Test/Stream/Compare/Scalar.pm
+++ b/lib/Test/Stream/Compare/Scalar.pm
@@ -2,11 +2,8 @@ package Test::Stream::Compare::Scalar;
 use strict;
 use warnings;
 
-use Test::Stream::Compare();
-use Test::Stream::HashBase(
-    base => 'Test::Stream::Compare',
-    accessors => [qw/item/],
-);
+use base 'Test::Stream::Compare';
+use Test::Stream::HashBase accessors => [qw/item/];
 
 use Carp qw/croak confess/;
 use Scalar::Util qw/reftype blessed/;

--- a/lib/Test/Stream/Compare/Set.pm
+++ b/lib/Test/Stream/Compare/Set.pm
@@ -2,11 +2,8 @@ package Test::Stream::Compare::Set;
 use strict;
 use warnings;
 
-use Test::Stream::Compare();
-use Test::Stream::HashBase(
-    base => 'Test::Stream::Compare',
-    accessors => [qw/checks _reduction/],
-);
+use base 'Test::Stream::Compare';
+use Test::Stream::HashBase accessors => [qw/checks _reduction/];
 
 use Test::Stream::Delta();
 

--- a/lib/Test/Stream/Compare/String.pm
+++ b/lib/Test/Stream/Compare/String.pm
@@ -4,11 +4,8 @@ use warnings;
 
 use Carp qw/confess/;
 
-use Test::Stream::Compare();
-use Test::Stream::HashBase(
-    base => 'Test::Stream::Compare',
-    accessors => [qw/input negate/],
-);
+use base 'Test::Stream::Compare';
+use Test::Stream::HashBase accessors => [qw/input negate/];
 
 sub stringify_got { 1 }
 

--- a/lib/Test/Stream/Compare/Undef.pm
+++ b/lib/Test/Stream/Compare/Undef.pm
@@ -4,11 +4,8 @@ use warnings;
 
 use Carp qw/confess/;
 
-use Test::Stream::Compare();
-use Test::Stream::HashBase(
-    base => 'Test::Stream::Compare',
-    accessors => [qw/negate/],
-);
+use base 'Test::Stream::Compare';
+use Test::Stream::HashBase accessors => [qw/negate/];
 
 sub name { '<UNDEF>' }
 

--- a/lib/Test/Stream/Compare/Value.pm
+++ b/lib/Test/Stream/Compare/Value.pm
@@ -6,11 +6,8 @@ use Scalar::Util qw/looks_like_number/;
 
 use Carp qw/carp/;
 
-use Test::Stream::Compare();
-use Test::Stream::HashBase(
-    base => 'Test::Stream::Compare',
-    accessors => [qw/input/],
-);
+use base 'Test::Stream::Compare';
+use Test::Stream::HashBase accessors => [qw/input/];
 
 sub init {
     my $self = shift;

--- a/lib/Test/Stream/Compare/Wildcard.pm
+++ b/lib/Test/Stream/Compare/Wildcard.pm
@@ -2,11 +2,8 @@ package Test::Stream::Compare::Wildcard;
 use strict;
 use warnings;
 
-use Test::Stream::Compare();
-use Test::Stream::HashBase(
-    base => 'Test::Stream::Compare',
-    accessors => [qw/expect/],
-);
+use base 'Test::Stream::Compare';
+use Test::Stream::HashBase accessors => [qw/expect/];
 
 use Carp qw/croak/;
 

--- a/lib/Test/Stream/Event.pm
+++ b/lib/Test/Stream/Event.pm
@@ -2,7 +2,7 @@ package Test::Stream::Event;
 use strict;
 use warnings;
 
-use Carp qw/confess/;
+use Carp qw/confess carp/;
 
 use Test::Stream::HashBase(
     accessors => [qw/debug nested/],
@@ -14,6 +14,8 @@ sub import {
     # Import should only when event is imported, subclasses do not use this
     # import.
     return if $class ne __PACKAGE__;
+
+    carp "The magical 'import' method on $class is deprecated and will be removed in the near future.";
 
     my $caller = caller;
     my (%args) = @_;
@@ -58,11 +60,11 @@ L<Test::Stream>.
     use strict;
     use warnings;
 
-    # This will make our class an event subclass, add the specified accessors,
-    # add constants for all our fields, and fields we inherit.
-    use Test::Stream::Event(
-        accessors  => [qw/foo bar baz/],
-    );
+    # This will make our class an event subclass (required)
+    use base 'Test::Stream::Event';
+
+    # Add some accessors
+    use Test::Stream::HashBase accessors => [qw/foo bar baz/];
 
     # Chance to initialize some defaults
     sub init {
@@ -81,37 +83,6 @@ L<Test::Stream>.
     }
 
     1;
-
-=head1 IMPORTING
-
-=head2 ARGUMENTS
-
-In addition to the arguments listed here, you may pass in any arguments
-accepted by L<Test::Stream::HashBase>.
-
-=over 4
-
-=item base => $BASE_CLASS
-
-This lets you specify an event class to subclass. B<THIS MUST BE AN EVENT
-CLASS>. If you do not specify anything here then C<Test::Stream::Event> will be
-used.
-
-=item accessors => \@FIELDS
-
-This lets you define any fields you wish to be present in your class. This is
-the only way to define storage for your event. Each field specified will get a
-read-only accessor with the same name as the field, as well as a setter
-C<set_FIELD()>. You will also get a constant that returns the index of the
-field in the classes arrayref. The constant is the name of the field in all
-upper-case.
-
-=back
-
-=head2 SUBCLASSING
-
-C<Test::Stream::Event> is added to your @INC for you, unless you specify an
-alternative base class, which must itself subclass C<Test::Stream::Event>.
 
 =head1 METHODS
 
@@ -178,7 +149,7 @@ is output to the specified handle.
 Example:
 
     package Test::Stream::Event::MyEvent;
-    use Test::Stream::Event;
+    use base 'Test::Stream::Event';
     use Test::Stream::Formatter::TAP qw/OUT_STD OUT_TODO OUT_ERR/;
 
     sub to_tap {

--- a/lib/Test/Stream/Event/Bail.pm
+++ b/lib/Test/Stream/Event/Bail.pm
@@ -4,9 +4,8 @@ use warnings;
 
 use Test::Stream::Formatter::TAP qw/OUT_STD/;
 
-use Test::Stream::Event(
-    accessors => [qw/reason/],
-);
+use base 'Test::Stream::Event';
+use Test::Stream::HashBase accessors => [qw/reason/];
 
 sub to_tap {
     my $self = shift;

--- a/lib/Test/Stream/Event/Diag.pm
+++ b/lib/Test/Stream/Event/Diag.pm
@@ -2,9 +2,8 @@ package Test::Stream::Event::Diag;
 use strict;
 use warnings;
 
-use Test::Stream::Event(
-    accessors => [qw/message/],
-);
+use base 'Test::Stream::Event';
+use Test::Stream::HashBase accessors => [qw/message/];
 
 use Carp qw/confess/;
 

--- a/lib/Test/Stream/Event/Exception.pm
+++ b/lib/Test/Stream/Event/Exception.pm
@@ -4,9 +4,8 @@ use warnings;
 
 use Test::Stream::Formatter::TAP qw/OUT_ERR/;
 
-use Test::Stream::Event(
-    accessors => [qw/error/],
-);
+use base 'Test::Stream::Event';
+use Test::Stream::HashBase accessors => [qw/error/];
 
 sub to_tap {
     my $self = shift;

--- a/lib/Test/Stream/Event/Note.pm
+++ b/lib/Test/Stream/Event/Note.pm
@@ -4,9 +4,8 @@ use warnings;
 
 use Test::Stream::Formatter::TAP qw/OUT_STD/;
 
-use Test::Stream::Event(
-    accessors  => [qw/message/],
-);
+use base 'Test::Stream::Event';
+use Test::Stream::HashBase accessors => [qw/message/];
 
 sub init {
     $_[0]->SUPER::init();

--- a/lib/Test/Stream/Event/Ok.pm
+++ b/lib/Test/Stream/Event/Ok.pm
@@ -9,9 +9,8 @@ use Test::Stream::Formatter::TAP qw/OUT_STD OUT_TODO OUT_ERR/;
 
 use Test::Stream::Event::Diag();
 
-use Test::Stream::Event(
-    accessors => [qw/pass effective_pass name diag allow_bad_name/],
-);
+use base 'Test::Stream::Event';
+use Test::Stream::HashBase accessors => [qw/pass effective_pass name diag allow_bad_name/];
 
 sub init {
     my $self = shift;

--- a/lib/Test/Stream/Event/Plan.pm
+++ b/lib/Test/Stream/Event/Plan.pm
@@ -2,9 +2,8 @@ package Test::Stream::Event::Plan;
 use strict;
 use warnings;
 
-use Test::Stream::Event(
-    accessors  => [qw/max directive reason/],
-);
+use base 'Test::Stream::Event';
+use Test::Stream::HashBase accessors => [qw/max directive reason/];
 
 use Test::Stream::Formatter::TAP qw/OUT_STD/;
 use Carp qw/confess/;

--- a/lib/Test/Stream/Event/Subtest.pm
+++ b/lib/Test/Stream/Event/Subtest.pm
@@ -7,11 +7,8 @@ use Carp qw/confess/;
 
 use Test::Stream::Formatter::TAP qw/OUT_STD/;
 
-use Test::Stream::Event::Ok();
-use Test::Stream::Event(
-    base       => 'Test::Stream::Event::Ok',
-    accessors  => [qw/subevents buffered/],
-);
+use base 'Test::Stream::Event::Ok';
+use Test::Stream::HashBase accessors => [qw/subevents buffered/];
 
 sub init {
     my $self = shift;

--- a/lib/Test/Stream/Event/Waiting.pm
+++ b/lib/Test/Stream/Event/Waiting.pm
@@ -2,7 +2,7 @@ package Test::Stream::Event::Waiting;
 use strict;
 use warnings;
 
-use Test::Stream::Event;
+use base 'Test::Stream::Event';
 
 sub global { 1 };
 

--- a/lib/Test/Stream/Hub/Interceptor.pm
+++ b/lib/Test/Stream/Hub/Interceptor.pm
@@ -4,10 +4,8 @@ use warnings;
 
 use Test::Stream::Hub::Interceptor::Terminator();
 
-require Test::Stream::Hub;
-use Test::Stream::HashBase(
-    base => 'Test::Stream::Hub',
-);
+use base 'Test::Stream::Hub';
+use Test::Stream::HashBase;
 
 sub inherit {
     my $self = shift;

--- a/lib/Test/Stream/Hub/Subtest.pm
+++ b/lib/Test/Stream/Hub/Subtest.pm
@@ -2,11 +2,8 @@ package Test::Stream::Hub::Subtest;
 use strict;
 use warnings;
 
-use Test::Stream::Hub();
-use Test::Stream::HashBase(
-    base => 'Test::Stream::Hub',
-    accessors => [qw/nested bailed_out exit_code/],
-);
+use base 'Test::Stream::Hub';
+use Test::Stream::HashBase accessors => [qw/nested bailed_out exit_code/];
 
 sub process {
     my $self = shift;

--- a/t/lib/Test/Stream/Event/Foo.pm
+++ b/t/lib/Test/Stream/Event/Foo.pm
@@ -2,6 +2,6 @@ package Test::Stream::Event::Foo;
 use strict;
 use warnings;
 
-use Test::Stream::Event;
+use base 'Test::Stream::Event';
 
 1;

--- a/t/modules/Event.t
+++ b/t/modules/Event.t
@@ -1,6 +1,6 @@
 use Test::Stream -V1;
 
-use Test::Stream::Event;
+use Test::Stream::Event();
 
 can_ok('Test::Stream::Event', qw/debug nested/);
 
@@ -11,9 +11,9 @@ like($err, qr/No debug info provided/, "Need debug info");
 
 {
     package My::MockEvent;
-    use Test::Stream::Event(
-        accessors => [qw/foo bar baz/],
-    );
+
+    use base 'Test::Stream::Event';
+    use Test::Stream::HashBase accessors => [qw/foo bar baz/];
 }
 
 can_ok('My::MockEvent', qw/foo bar baz/);

--- a/t/modules/Formatter/TAP.t
+++ b/t/modules/Formatter/TAP.t
@@ -39,9 +39,8 @@ ok($layers->{utf8}, "Now utf8");
     package My::Event;
     use Test::Stream::Formatter::TAP qw/OUT_STD OUT_ERR/;
 
-    use Test::Stream::Event(
-        accessors => [qw/pass name diag note/],
-    );
+    use base 'Test::Stream::Event';
+    use Test::Stream::HashBase accessors => [qw/pass name diag note/];
 
     sub to_tap {
         my $self = shift;

--- a/t/modules/Hub.t
+++ b/t/modules/Hub.t
@@ -17,9 +17,8 @@ use Test::Stream::Capabilities qw/CAN_FORK CAN_THREAD CAN_REALLY_FORK/;
 {
     package My::Event;
 
-    use Test::Stream::Event(
-        accessors => [qw/msg/],
-    );
+    use base 'Test::Stream::Event';
+    use Test::Stream::HashBase accessors => [qw/msg/];
 }
 
 tests basic => sub {

--- a/t/modules/IPC/Files.t
+++ b/t/modules/IPC/Files.t
@@ -30,7 +30,7 @@ if(ok(open(my $fh, '<', $ipc->tempdir . '/HUB-' . $hid), "opened hub file")) {
 
 {
     package Foo;
-    use Test::Stream::Event;
+    use base 'Test::Stream::Event';
 }
 
 $ipc->send($hid, bless({ foo => 1 }, 'Foo'));


### PR DESCRIPTION
Seperating these into 2 commits is not practical, they were fairly well
intertwined.

 * Event magical import is deprecated, and going away
 * 'base' import to HashBase is deprecated
 * Hashbase checks @ISA to handle base, so people just 'use base ...'