### PR TITLE
Move TAP logic out of events

### DIFF
--- a/lib/Test/Stream/Event.pm
+++ b/lib/Test/Stream/Event.pm
@@ -32,10 +32,20 @@ sub init {
 
 sub causes_fail  { 0 }
 
-sub to_tap       {()};
 sub update_state {()};
 sub terminate    {()};
 sub global       {()};
+
+sub to_tap {
+    my $self = shift;
+    my ($num) = @_;
+
+    carp 'Use of $event->to_tap is deprecated';
+
+    require Test::Stream::Formatter::TAP;
+    my $formatter = Test::Stream::Formatter::TAP->new;
+    $formatter->event_tap($self, $num);
+}
 
 1;
 
@@ -138,6 +148,9 @@ This is called after the event has been sent to the formatter in order to
 ensure the event is seen and understood.
 
 =item @output = $e->to_tap($num)
+
+B<***DEPRECATED***> This will be removed in the near future. See
+L<Test::Stream::Formatter::TAP> for TAP production.
 
 This is where you get the chance to produce TAP output. The input argument
 C<$num> will either be the most recent test number, or undefined. The output

--- a/lib/Test/Stream/Event/Bail.pm
+++ b/lib/Test/Stream/Event/Bail.pm
@@ -7,14 +7,6 @@ use Test::Stream::Formatter::TAP qw/OUT_STD/;
 use base 'Test::Stream::Event';
 use Test::Stream::HashBase accessors => [qw/reason/];
 
-sub to_tap {
-    my $self = shift;
-    return [
-        OUT_STD,
-        "Bail out!  " . $self->reason . "\n",
-    ];
-}
-
 sub update_state {
     my $self = shift;
     my ($state) = @_;

--- a/lib/Test/Stream/Event/Diag.pm
+++ b/lib/Test/Stream/Event/Diag.pm
@@ -19,23 +19,6 @@ sub init {
     }
 }
 
-sub to_tap {
-    my $self = shift;
-
-    my $msg = $self->{+MESSAGE};
-    return unless $msg;
-
-    $msg = "# $msg" unless $msg eq "\n";
-
-    chomp($msg);
-    $msg =~ s/\n/\n# /g;
-
-    return [
-        ($self->{+DEBUG}->no_diag ? OUT_TODO : OUT_ERR),
-        "$msg\n",
-    ];
-}
-
 1;
 
 __END__

--- a/lib/Test/Stream/Event/Exception.pm
+++ b/lib/Test/Stream/Event/Exception.pm
@@ -7,13 +7,6 @@ use Test::Stream::Formatter::TAP qw/OUT_ERR/;
 use base 'Test::Stream::Event';
 use Test::Stream::HashBase accessors => [qw/error/];
 
-sub to_tap {
-    my $self = shift;
-    return [
-        OUT_ERR, $self->{+ERROR}
-    ];
-}
-
 sub update_state {
     my $self = shift;
     my ($state) = @_;

--- a/lib/Test/Stream/Event/Note.pm
+++ b/lib/Test/Stream/Event/Note.pm
@@ -17,17 +17,6 @@ sub init {
     }
 }
 
-sub to_tap {
-    my $self = shift;
-
-    chomp(my $msg = $self->{+MESSAGE});
-    return unless $msg;
-    $msg = "# $msg" unless $msg =~ m/^\n/;
-    $msg =~ s/\n/\n# /g;
-
-    return [OUT_STD, "$msg\n"];
-}
-
 1;
 
 __END__

--- a/lib/Test/Stream/Event/Ok.pm
+++ b/lib/Test/Stream/Event/Ok.pm
@@ -28,51 +28,6 @@ sub init {
     $self->debug->throw("'$name' is not a valid name, names must not contain '#' or newlines.")
 }
 
-sub to_tap {
-    my $self = shift;
-    my ($num) = @_;
-
-    my $name  = $self->{+NAME};
-    my $debug = $self->{+DEBUG};
-    my $skip  = $debug->{skip};
-    my $todo  = $debug->{todo};
-
-    my $out = "";
-    $out .= "not " unless $self->{+PASS};
-    $out .= "ok";
-    $out .= " $num" if defined $num;
-    $out .= " - $name" if $name;
-
-    if (defined $skip && defined $todo) {
-        $out .= " # TODO & SKIP";
-        $out .= " $todo" if length $todo;
-    }
-    elsif (defined $todo) {
-        $out .= " # TODO";
-        $out .= " $todo" if length $todo;
-    }
-    elsif (defined $skip) {
-        $out .= " # skip";
-        $out .= " $skip" if length $skip;
-    }
-
-    my @out = [OUT_STD, "$out\n"];
-
-    if ($self->{+DIAG} && @{$self->{+DIAG}}) {
-        my $diag_handle = $debug->no_diag ? OUT_TODO : OUT_ERR;
-
-        for my $diag (@{$self->{+DIAG}}) {
-            chomp(my $msg = $diag);
-
-            $msg = "# $msg" unless $msg =~ m/^\n/;
-            $msg =~ s/\n/\n# /g;
-            push @out => [$diag_handle, "$msg\n"];
-        }
-    }
-
-    return @out;
-}
-
 sub default_diag {
     my $self = shift;
 
@@ -184,6 +139,9 @@ This generates the default diagnostics string:
 =item @sets = $e->to_tap()
 
 =item @sets = $e->to_tap($num)
+
+B<***DEPRECATED***> This will be removed in the near future. See
+L<Test::Stream::Formatter::TAP> for TAP production.
 
 Generate the tap stream for this object. C<@sets> containes 1 or more arrayrefs
 that identify the IO handle to use, and the string that should be sent to it.

--- a/lib/Test/Stream/Event/Plan.pm
+++ b/lib/Test/Stream/Event/Plan.pm
@@ -37,24 +37,6 @@ sub init {
     }
 }
 
-sub to_tap {
-    my $self = shift;
-
-    my $max       = $self->{+MAX};
-    my $directive = $self->{+DIRECTIVE};
-    my $reason    = $self->{+REASON};
-
-    return if $directive && $directive eq 'NO PLAN';
-
-    my $plan = "1..$max";
-    if ($directive) {
-        $plan .= " # $directive";
-        $plan .= " $reason" if defined $reason;
-    }
-
-    return [OUT_STD, "$plan\n"];
-}
-
 sub update_state {
     my $self = shift;
     my ($state) = @_;

--- a/lib/Test/Stream/Event/Subtest.pm
+++ b/lib/Test/Stream/Event/Subtest.pm
@@ -16,37 +16,6 @@ sub init {
     $self->{+SUBEVENTS} ||= [];
 }
 
-sub to_tap {
-    my $self = shift;
-    my ($num) = @_;
-
-    my ($ok, @diag) = $self->SUPER::to_tap($num);
-
-    return (
-        $ok,
-        @diag
-    ) unless $self->{+BUFFERED};
-
-    if ($ENV{HARNESS_IS_VERBOSE}) {
-        $_->[1] =~ s/^/    /mg for @diag;
-    }
-
-    $ok->[1] =~ s/\n/ {\n/;
-
-    my $count = 0;
-    my @subs = map {
-        $count++ if $_->isa('Test::Stream::Event::Ok');
-        map { $_->[1] =~ s/^/    /mg; $_ } $_->to_tap($count);
-    } @{$self->{+SUBEVENTS}};
-
-    return (
-        $ok,
-        @diag,
-        @subs,
-        [OUT_STD(), "}\n"],
-    );
-}
-
 1;
 
 __END__

--- a/lib/Test/Stream/Formatter/TAP.pm
+++ b/lib/Test/Stream/Formatter/TAP.pm
@@ -12,6 +12,7 @@ sub OUT_ERR()  { 1 }
 sub OUT_TODO() { 2 }
 
 use Scalar::Util qw/blessed/;
+use Carp qw/croak/;
 
 use Test::Stream::Exporter qw/import exports/;
 exports qw/OUT_STD OUT_ERR OUT_TODO/;
@@ -26,6 +27,16 @@ my %CONVERTERS = (
     'Test::Stream::Event::Subtest'   => \&_subtest_event,
     'Test::Stream::Event::Plan'      => \&_plan_event,
 );
+
+sub register_event {
+    my $class = shift;
+    my ($type, $convert) = @_;
+    croak "Event type is a required argument" unless $type;
+    croak "Event type '$type' already registered" if $CONVERTERS{$type};
+    croak "The second argument to register_event() must be a code reference"
+        unless $convert && ref($convert) eq 'CODE';
+    $CONVERTERS{$type} = $convert;
+}
 
 _autoflush(\*STDOUT);
 _autoflush(\*STDERR);

--- a/t/modules/Event.t
+++ b/t/modules/Event.t
@@ -25,6 +25,8 @@ ok(!$one->causes_fail, "Events do not cause failures by default");
 
 ok(!$one->$_, "$_ is false by default") for qw/update_state terminate global/;
 
-is([$one->to_tap()], [], "to_tap is an empty list by default");
+warns {
+    is([$one->to_tap()], [], "to_tap is an empty list by default");
+};
 
 done_testing;

--- a/t/modules/Event/Bail.t
+++ b/t/modules/Event/Bail.t
@@ -11,11 +11,13 @@ my $bail = Test::Stream::Event::Bail->new(
 
 ok($bail->causes_fail, "balout always causes fail.");
 
-is(
-    [$bail->to_tap(1)],
-    [[OUT_STD, "Bail out!  evil\n" ]],
-    "Got tap"
-);
+warns {
+    is(
+        [$bail->to_tap(1)],
+        [[OUT_STD, "Bail out!  evil\n" ]],
+        "Got tap"
+    );
+};
 
 is($bail->terminate, 255, "Bail will cause the test to exit.");
 is($bail->global, 1, "Bail is global, everything should bail");

--- a/t/modules/Event/Diag.t
+++ b/t/modules/Event/Diag.t
@@ -10,32 +10,34 @@ my $diag = Test::Stream::Event::Diag->new(
     message => 'foo',
 );
 
-is(
-    [$diag->to_tap(1)],
-    [[OUT_ERR, "# foo\n"]],
-    "Got tap"
-);
+warns {
+    is(
+        [$diag->to_tap(1)],
+        [[OUT_ERR, "# foo\n"]],
+        "Got tap"
+    );
 
-$diag->set_message("foo\n");
-is(
-    [$diag->to_tap(1)],
-    [[OUT_ERR, "# foo\n"]],
-    "Only 1 newline"
-);
+    $diag->set_message("foo\n");
+    is(
+        [$diag->to_tap(1)],
+        [[OUT_ERR, "# foo\n"]],
+        "Only 1 newline"
+    );
 
-$diag->debug->set_todo('todo');
-is(
-    [$diag->to_tap(1)],
-    [[OUT_TODO, "# foo\n"]],
-    "Got tap in todo"
-);
+    $diag->debug->set_todo('todo');
+    is(
+        [$diag->to_tap(1)],
+        [[OUT_TODO, "# foo\n"]],
+        "Got tap in todo"
+    );
 
-$diag->set_message("foo\nbar\nbaz");
-is(
-    [$diag->to_tap(1)],
-    [[OUT_TODO, "# foo\n# bar\n# baz\n"]],
-    "All lines have proper prefix"
-);
+    $diag->set_message("foo\nbar\nbaz");
+    is(
+        [$diag->to_tap(1)],
+        [[OUT_TODO, "# foo\n# bar\n# baz\n"]],
+        "All lines have proper prefix"
+    );
+};
 
 $diag = Test::Stream::Event::Diag->new(
     debug => Test::Stream::DebugInfo->new(frame => [__PACKAGE__, __FILE__, __LINE__]),
@@ -51,10 +53,12 @@ $diag = Test::Stream::Event::Diag->new(
 
 like($diag->message, qr/^HASH\(.*\)$/, "stringified the input value");
 
-$diag->set_message("");
-is([$diag->to_tap], [], "no tap with an empty message");
+warns {
+    $diag->set_message("");
+    is([$diag->to_tap], [], "no tap with an empty message");
 
-$diag->set_message("\n");
-is([$diag->to_tap], [[OUT_ERR, "\n"]], "newline on its own is unchanged");
+    $diag->set_message("\n");
+    is([$diag->to_tap], [[OUT_ERR, "\n"]], "newline on its own is unchanged");
+};
 
 done_testing;

--- a/t/modules/Event/Exception.t
+++ b/t/modules/Event/Exception.t
@@ -11,11 +11,13 @@ my $exception = Test::Stream::Event::Exception->new(
 
 ok($exception->causes_fail, "Exception events always cause failure");
 
-is(
-    [$exception->to_tap(1)],
-    [[OUT_ERR, "evil at lake_of_fire.t line 6\n" ]],
-    "Got tap"
-);
+warns {
+    is(
+        [$exception->to_tap(1)],
+        [[OUT_ERR, "evil at lake_of_fire.t line 6\n" ]],
+        "Got tap"
+    );
+};
 
 require Test::Stream::State;
 my $state = Test::Stream::State->new;

--- a/t/modules/Event/Note.t
+++ b/t/modules/Event/Note.t
@@ -12,25 +12,27 @@ my $note = Test::Stream::Event::Note->new(
     message => 'foo',
 );
 
-is(
-    [$note->to_tap(1)],
-    [[OUT_STD, "# foo\n"]],
-    "Got tap"
-);
-
-$note->set_message("foo\n");
-is(
-    [$note->to_tap(1)],
-    [[OUT_STD, "# foo\n"]],
-    "Only 1 newline"
-);
-
-$note->set_message("foo\nbar\nbaz");
-is(
-    [$note->to_tap(1)],
-    [[OUT_STD, "# foo\n# bar\n# baz\n"]],
-    "All lines have proper prefix"
-);
+warns {
+    is(
+        [$note->to_tap(1)],
+        [[OUT_STD, "# foo\n"]],
+        "Got tap"
+    );
+    
+    $note->set_message("foo\n");
+    is(
+        [$note->to_tap(1)],
+        [[OUT_STD, "# foo\n"]],
+        "Only 1 newline"
+    );
+    
+    $note->set_message("foo\nbar\nbaz");
+    is(
+        [$note->to_tap(1)],
+        [[OUT_STD, "# foo\n# bar\n# baz\n"]],
+        "All lines have proper prefix"
+    );
+};
 
 $note = Test::Stream::Event::Note->new(
     debug => Test::Stream::DebugInfo->new(frame => [__PACKAGE__, __FILE__, __LINE__]),
@@ -46,13 +48,15 @@ $note = Test::Stream::Event::Note->new(
 
 like($note->message, qr/^HASH\(.*\)$/, "stringified the input value");
 
-$note->set_message("");
-is([$note->to_tap], [], "no tap with an empty message");
-
-$note->set_message("\n");
-is([$note->to_tap], [], "newline on its own is not shown");
-
-$note->set_message("\nxxx");
-is([$note->to_tap], [[OUT_STD, "\n# xxx\n"]], "newline starting");
+warns {
+    $note->set_message("");
+    is([$note->to_tap], [], "no tap with an empty message");
+    
+    $note->set_message("\n");
+    is([$note->to_tap], [], "newline on its own is not shown");
+    
+    $note->set_message("\nxxx");
+    is([$note->to_tap], [[OUT_STD, "\n# xxx\n"]], "newline starting");
+};
 
 done_testing;

--- a/t/modules/Event/Ok.t
+++ b/t/modules/Event/Ok.t
@@ -27,11 +27,13 @@ tests Passing => sub {
     is($ok->effective_pass, 1, "effective pass");
     is($ok->diag, undef, "no diag");
 
-    is(
-        [$ok->to_tap(4)],
-        [[OUT_STD, "ok 4 - the_test\n"]],
-        "Got tap for basic ok"
-    );
+    warns {
+        is(
+            [$ok->to_tap(4)],
+            [[OUT_STD, "ok 4 - the_test\n"]],
+            "Got tap for basic ok"
+        );
+    };
 
     my $state = Test::Stream::State->new;
     $ok->update_state($state);
@@ -53,13 +55,15 @@ tests Failing => sub {
     is($ok->name, 'the_test', "got name");
     is($ok->effective_pass, 0, "effective pass");
 
-    is(
-        [$ok->to_tap(4)],
-        [
-            [OUT_STD, "not ok 4 - the_test\n"],
-        ],
-        "Got tap for failing ok"
-    );
+    warns {
+        is(
+            [$ok->to_tap(4)],
+            [
+                [OUT_STD, "not ok 4 - the_test\n"],
+            ],
+            "Got tap for failing ok"
+        );
+    };
 
     is(
         $ok->default_diag,
@@ -67,37 +71,39 @@ tests Failing => sub {
         "default diag"
     );
 
-    $ok->set_diag([ $ok->default_diag ]);
-    is(
-        [$ok->to_tap(4)],
-        [
-            [OUT_STD, "not ok 4 - the_test\n"],
-            [OUT_ERR, "# Failed test 'the_test'\n# at foo.t line 42.\n"],
-        ],
-        "Got tap for failing ok with diag"
-    );
+    warns {
+        $ok->set_diag([ $ok->default_diag ]);
+        is(
+            [$ok->to_tap(4)],
+            [
+                [OUT_STD, "not ok 4 - the_test\n"],
+                [OUT_ERR, "# Failed test 'the_test'\n# at foo.t line 42.\n"],
+            ],
+            "Got tap for failing ok with diag"
+        );
 
-    $ENV{HARNESS_IS_VERBOSE} = 0;
-    $ok->set_diag([ $ok->default_diag ]);
-    is(
-        [$ok->to_tap(4)],
-        [
-            [OUT_STD, "not ok 4 - the_test\n"],
-            [OUT_ERR, "\n# Failed test 'the_test'\n# at foo.t line 42.\n"],
-        ],
-        "Got tap for failing ok with diag non verbose harness"
-    );
-
-    $ENV{HARNESS_ACTIVE} = 0;
-    $ok->set_diag([ $ok->default_diag ]);
-    is(
-        [$ok->to_tap(4)],
-        [
-            [OUT_STD, "not ok 4 - the_test\n"],
-            [OUT_ERR, "# Failed test 'the_test'\n# at foo.t line 42.\n"],
-        ],
-        "Got tap for failing ok with diag no harness"
-    );
+        $ENV{HARNESS_IS_VERBOSE} = 0;
+        $ok->set_diag([ $ok->default_diag ]);
+        is(
+            [$ok->to_tap(4)],
+            [
+                [OUT_STD, "not ok 4 - the_test\n"],
+                [OUT_ERR, "\n# Failed test 'the_test'\n# at foo.t line 42.\n"],
+            ],
+            "Got tap for failing ok with diag non verbose harness"
+        );
+    
+        $ENV{HARNESS_ACTIVE} = 0;
+        $ok->set_diag([ $ok->default_diag ]);
+        is(
+            [$ok->to_tap(4)],
+            [
+                [OUT_STD, "not ok 4 - the_test\n"],
+                [OUT_ERR, "# Failed test 'the_test'\n# at foo.t line 42.\n"],
+            ],
+            "Got tap for failing ok with diag no harness"
+        );
+    };
 
     my $state = Test::Stream::State->new;
     $ok->update_state($state);
@@ -126,14 +132,16 @@ tests fail_with_diag => sub {
         "Got diag"
     );
 
-    is(
-        [$ok->to_tap(4)],
-        [
-            [OUT_STD, "not ok 4 - the_test\n"],
-            [OUT_ERR, "# xxx\n"],
-        ],
-        "Got tap for failing ok"
-    );
+    warns {
+        is(
+            [$ok->to_tap(4)],
+            [
+                [OUT_STD, "not ok 4 - the_test\n"],
+                [OUT_ERR, "# xxx\n"],
+            ],
+            "Got tap for failing ok"
+        );
+    };
 
     my $state = Test::Stream::State->new;
     $ok->update_state($state);
@@ -163,14 +171,16 @@ tests "Failing TODO" => sub {
         "Got diag"
     );
 
-    is(
-        [$ok->to_tap(4)],
-        [
-            [OUT_STD, "not ok 4 - the_test # TODO A Todo\n"],
-            [OUT_TODO, "# Failed (TODO) test 'the_test'\n# at foo.t line 42.\n"],
-        ],
-        "Got tap for failing ok"
-    );
+    warns {
+        is(
+            [$ok->to_tap(4)],
+            [
+                [OUT_STD, "not ok 4 - the_test # TODO A Todo\n"],
+                [OUT_TODO, "# Failed (TODO) test 'the_test'\n# at foo.t line 42.\n"],
+            ],
+            "Got tap for failing ok"
+        );
+    };
 
     my $state = Test::Stream::State->new;
     $ok->update_state($state);
@@ -195,13 +205,15 @@ tests skip => sub {
     is($ok->effective_pass, 1, "effective pass");
     is($ok->diag, undef, "no diag");
 
-    is(
-        [$ok->to_tap(4)],
-        [
-            [OUT_STD, "ok 4 - the_test # skip A Skip\n"],
-        ],
-        "Got tap for skip"
-    );
+    warns {
+        is(
+            [$ok->to_tap(4)],
+            [
+                [OUT_STD, "ok 4 - the_test # skip A Skip\n"],
+            ],
+            "Got tap for skip"
+        );
+    };
 
     my $state = Test::Stream::State->new;
     $ok->update_state($state);
@@ -261,6 +273,11 @@ describe to_tap => sub {
     my $pass;
     case pass => sub { $pass = 1 };
     case fail => sub { $pass = 0 };
+
+    around_all hide_warnings => sub {
+        local $SIG{__WARN__} = sub { 1 };
+        $_[0]->();
+    };
 
     tests name_and_number => sub {
         my $ok = Test::Stream::Event::Ok->new(debug => $dbg, pass => $pass, name => 'foo');

--- a/t/modules/Event/Plan.t
+++ b/t/modules/Event/Plan.t
@@ -13,11 +13,13 @@ my $plan = Test::Stream::Event::Plan->new(
     max => 100,
 );
 
-is(
-    [$plan->to_tap(1)],
-    [[OUT_STD, "1..100\n"]],
-    "Got tap"
-);
+warns {
+    is(
+        [$plan->to_tap(1)],
+        [[OUT_STD, "1..100\n"]],
+        "Got tap"
+    );
+};
 ok(!$plan->global, "regular plan is not a global event");
 my $state = Test::Stream::State->new;
 $plan->update_state($state);
@@ -27,11 +29,13 @@ is($plan->terminate, undef, "No terminate for normal plan");
 $plan->set_max(0);
 $plan->set_directive('SKIP');
 $plan->set_reason('foo');
-is(
-    [$plan->to_tap(1)],
-    [[OUT_STD, "1..0 # SKIP foo\n"]],
-    "Got tap for skip_all"
-);
+warns {
+    is(
+        [$plan->to_tap(1)],
+        [[OUT_STD, "1..0 # SKIP foo\n"]],
+        "Got tap for skip_all"
+    );
+};
 ok($plan->global, "plan is global on skip all");
 $state = Test::Stream::State->new;
 $plan->update_state($state);
@@ -57,11 +61,13 @@ $plan = Test::Stream::Event::Plan->new(
     directive => 'skip_all',
 );
 is($plan->directive, 'SKIP', "Change skip_all to SKIP");
-is(
-    [$plan->to_tap],
-    [[OUT_STD, "1..0 # SKIP\n"]],
-    "SKIP without reason"
-);
+warns {
+    is(
+        [$plan->to_tap],
+        [[OUT_STD, "1..0 # SKIP\n"]],
+        "SKIP without reason"
+    );
+};
 
 $plan = Test::Stream::Event::Plan->new(
     debug => Test::Stream::DebugInfo->new(frame => [__PACKAGE__, __FILE__, __LINE__]),
@@ -70,11 +76,13 @@ $plan = Test::Stream::Event::Plan->new(
 );
 is($plan->directive, 'NO PLAN', "Change no_plan to 'NO PLAN'");
 ok(!$plan->global, "NO PLAN is not global");
-is(
-    [$plan->to_tap],
-    [],
-    "NO PLAN"
-);
+warns {
+    is(
+        [$plan->to_tap],
+        [],
+        "NO PLAN"
+    );
+};
 
 like(
     dies {

--- a/t/modules/Event/Subtest.t
+++ b/t/modules/Event/Subtest.t
@@ -15,23 +15,27 @@ my $one = $st->new(
 isa_ok($one, $st, 'Test::Stream::Event::Ok');
 is($one->subevents, [], "subevents is an arrayref");
 
-is(
-    [$one->to_tap(5)],
-    [
-        [OUT_STD, "ok 5 - foo {\n"],
-        [OUT_STD, "}\n"],
-    ],
-    "Got Buffered TAP output"
-);
+warns {
+    is(
+        [$one->to_tap(5)],
+        [
+            [OUT_STD, "ok 5 - foo {\n"],
+            [OUT_STD, "}\n"],
+        ],
+        "Got Buffered TAP output"
+    );
+};
 
 $one->set_buffered(0);
-is(
-    [$one->to_tap(5)],
-    [
-        [OUT_STD, "ok 5 - foo\n"],
-    ],
-    "Got Unbuffered TAP output"
-);
+warns {
+    is(
+        [$one->to_tap(5)],
+        [
+            [OUT_STD, "ok 5 - foo\n"],
+        ],
+        "Got Unbuffered TAP output"
+    );
+};
 
 $dbg = Test::Stream::DebugInfo->new(frame => [__PACKAGE__, __FILE__, __LINE__, 'xxx']);
 $one = $st->new(
@@ -51,7 +55,7 @@ $one = $st->new(
     ],
 );
 
-{
+warns {
     local $ENV{HARNESS_IS_VERBOSE};
     is(
         [$one->to_tap(5)],
@@ -68,9 +72,9 @@ $one = $st->new(
         ],
         "Got Buffered TAP output (non-verbose)"
     );
-}
+};
 
-{
+warns {
     local $ENV{HARNESS_IS_VERBOSE} = 1;
     is(
         [$one->to_tap(5)],
@@ -87,9 +91,9 @@ $one = $st->new(
         ],
         "Got Buffered TAP output (verbose)"
     );
-}
+};
 
-{
+warns {
     local $ENV{HARNESS_IS_VERBOSE};
     $one->set_buffered(0);
     is(
@@ -101,9 +105,9 @@ $one = $st->new(
         ],
         "Got Unbuffered TAP output (non-verbose)"
     );
-}
+};
 
-{
+warns {
     local $ENV{HARNESS_IS_VERBOSE} = 1;
     $one->set_buffered(0);
     is(
@@ -115,7 +119,6 @@ $one = $st->new(
         ],
         "Got Unbuffered TAP output (verbose)"
     );
-}
-
+};
 
 done_testing;

--- a/t/modules/Formatter/TAP.t
+++ b/t/modules/Formatter/TAP.t
@@ -1,10 +1,7 @@
-use strict;
-use warnings;
-
-use Test::Stream qw/Core Compare/;
+use Test::Stream -V1, -SpecTester, '!UTF8', Compare => '*';
 use PerlIO;
 
-use Test::Stream::Formatter::TAP;
+use Test::Stream::Formatter::TAP qw/OUT_STD OUT_ERR OUT_TODO/;
 
 ok(my $one = Test::Stream::Formatter::TAP->new, "Created a new instance");
 isa_ok($one, 'Test::Stream::Formatter::TAP');
@@ -125,5 +122,432 @@ $it->write($_, 1) for $ok, $diag, $plan, $bail;
 # This checks that the plan, the diag, and the bail are not rendered
 is($std, "ok - xxx\n", "Only got the 'ok'");
 is($err, "", "no diag");
+
+describe events => sub {
+    my $fmt = Test::Stream::Formatter::TAP->new;
+    my $dbg;
+    before_each dbg => sub {
+        $dbg = Test::Stream::DebugInfo->new(
+            frame => ['main_foo', 'foo.t', 42, 'main_foo::flubnarb'],
+        );
+    };
+
+    tests bail => sub {
+        my $bail = Test::Stream::Event::Bail->new(
+            debug => $dbg,
+            reason => 'evil',
+        );
+
+        is(
+            [$fmt->event_tap($bail, 1)],
+            [[OUT_STD, "Bail out!  evil\n" ]],
+            "Got tap"
+        );
+    };
+
+    tests diag => sub {
+        my $diag = Test::Stream::Event::Diag->new(
+            debug => $dbg,
+            message => 'foo',
+        );
+
+        is(
+            [$fmt->event_tap($diag, 1)],
+            [[OUT_ERR, "# foo\n"]],
+            "Got tap"
+        );
+
+        $diag->set_message("foo\n");
+        is(
+            [$fmt->event_tap($diag, 1)],
+            [[OUT_ERR, "# foo\n"]],
+            "Only 1 newline"
+        );
+
+        $diag->debug->set_todo('todo');
+        is(
+            [$fmt->event_tap($diag, 1)],
+            [[OUT_TODO, "# foo\n"]],
+            "Got tap in todo"
+        );
+
+        $diag->set_message("foo\nbar\nbaz");
+        is(
+            [$fmt->event_tap($diag, 1)],
+            [[OUT_TODO, "# foo\n# bar\n# baz\n"]],
+            "All lines have proper prefix"
+        );
+
+        $diag->debug->set_todo(undef);
+        $diag->set_message("");
+        is([$fmt->event_tap($diag)], [], "no tap with an empty message");
+
+        $diag->set_message("\n");
+        is([$fmt->event_tap($diag)], [[OUT_ERR, "\n"]], "newline on its own is unchanged");
+    };
+
+    tests exception => sub {
+        my $exception = Test::Stream::Event::Exception->new(
+            debug => $dbg,
+            error => "evil at lake_of_fire.t line 6\n",
+        );
+
+        is(
+            [$fmt->event_tap($exception, 1)],
+            [[OUT_ERR, "evil at lake_of_fire.t line 6\n" ]],
+            "Got tap"
+        );
+    };
+
+    tests note => sub {
+        my $note = Test::Stream::Event::Note->new(
+            debug => $dbg,
+            message => 'foo',
+        );
+
+        is(
+            [$fmt->event_tap($note, 1)],
+            [[OUT_STD, "# foo\n"]],
+            "Got tap"
+        );
+
+        $note->set_message("foo\n");
+        is(
+            [$fmt->event_tap($note, 1)],
+            [[OUT_STD, "# foo\n"]],
+            "Only 1 newline"
+        );
+
+        $note->set_message("foo\nbar\nbaz");
+        is(
+            [$fmt->event_tap($note, 1)],
+            [[OUT_STD, "# foo\n# bar\n# baz\n"]],
+            "All lines have proper prefix"
+        );
+
+        $note->set_message("");
+        is([$fmt->event_tap($note)], [], "no tap with an empty message");
+
+        $note->set_message("\n");
+        is([$fmt->event_tap($note)], [], "newline on its own is not shown");
+
+        $note->set_message("\nxxx");
+        is([$fmt->event_tap($note)], [[OUT_STD, "\n# xxx\n"]], "newline starting");
+    };
+
+    describe ok => sub {
+        my $pass;
+        case pass => sub { $pass = 1 };
+        case fail => sub { $pass = 0 };
+
+        tests name_and_number => sub {
+            my $ok = Test::Stream::Event::Ok->new(debug => $dbg, pass => $pass, name => 'foo');
+            my @tap = $fmt->event_tap($ok, 7);
+            is(
+                \@tap,
+                [
+                    [OUT_STD, ($pass ? 'ok' : 'not ok') . " 7 - foo\n"],
+                ],
+                "Got expected output"
+            );
+        };
+
+        tests no_number => sub {
+            my $ok = Test::Stream::Event::Ok->new(debug => $dbg, pass => $pass, name => 'foo');
+            my @tap = $fmt->event_tap($ok, );
+            is(
+                \@tap,
+                [
+                    [OUT_STD, ($pass ? 'ok' : 'not ok') . " - foo\n"],
+                ],
+                "Got expected output"
+            );
+        };
+
+        tests no_name => sub {
+            my $ok = Test::Stream::Event::Ok->new(debug => $dbg, pass => $pass);
+            my @tap = $fmt->event_tap($ok, 7);
+            is(
+                \@tap,
+                [
+                    [OUT_STD, ($pass ? 'ok' : 'not ok') . " 7\n"],
+                ],
+                "Got expected output"
+            );
+        };
+
+        tests skip_and_todo => sub {
+            $dbg->set_todo('a');
+            $dbg->set_skip('b');
+
+            my $ok = Test::Stream::Event::Ok->new(debug => $dbg, pass => $pass);
+            my @tap = $fmt->event_tap($ok, 7);
+            is(
+                \@tap,
+                [
+                    [OUT_STD, ($pass ? 'ok' : 'not ok') . " 7 # TODO & SKIP a\n"],
+                ],
+                "Got expected output"
+            );
+
+            $dbg->set_todo("");
+
+            @tap = $fmt->event_tap($ok, 7);
+            is(
+                \@tap,
+                [
+                    [OUT_STD, ($pass ? 'ok' : 'not ok') . " 7 # TODO & SKIP\n"],
+                ],
+                "Got expected output"
+            );
+        };
+
+        tests skip => sub {
+            $dbg->set_skip('b');
+
+            my $ok = Test::Stream::Event::Ok->new(debug => $dbg, pass => $pass);
+            my @tap = $fmt->event_tap($ok, 7);
+            is(
+                \@tap,
+                [
+                    [OUT_STD, ($pass ? 'ok' : 'not ok') . " 7 # skip b\n"],
+                ],
+                "Got expected output"
+            );
+
+            $dbg->set_skip("");
+
+            @tap = $fmt->event_tap($ok, 7);
+            is(
+                \@tap,
+                [
+                    [OUT_STD, ($pass ? 'ok' : 'not ok') . " 7 # skip\n"],
+                ],
+                "Got expected output"
+            );
+        };
+
+        tests todo => sub {
+            $dbg->set_todo('b');
+
+            my $ok = Test::Stream::Event::Ok->new(debug => $dbg, pass => $pass);
+            my @tap = $fmt->event_tap($ok, 7);
+            is(
+                \@tap,
+                [
+                    [OUT_STD, ($pass ? 'ok' : 'not ok') . " 7 # TODO b\n"],
+                ],
+                "Got expected output"
+            );
+
+            $dbg->set_todo("");
+
+            @tap = $fmt->event_tap($ok, 7);
+            is(
+                \@tap,
+                [
+                    [OUT_STD, ($pass ? 'ok' : 'not ok') . " 7 # TODO\n"],
+                ],
+                "Got expected output"
+            );
+        };
+
+        tests empty_diag_array => sub {
+            my $ok = Test::Stream::Event::Ok->new(debug => $dbg, pass => $pass, diag => []);
+            my @tap = $fmt->event_tap($ok, 7);
+            is(
+                \@tap,
+                [
+                    [OUT_STD, ($pass ? 'ok' : 'not ok') . " 7\n"],
+                ],
+                "Got expected output (No diag)"
+            );
+
+            $ok = Test::Stream::Event::Ok->new(debug => $dbg, pass => $pass);
+            @tap = $fmt->event_tap($ok, 7);
+            is(
+                \@tap,
+                [
+                    [OUT_STD, ($pass ? 'ok' : 'not ok') . " 7\n"],
+                ],
+                "Got expected output (No diag)"
+            );
+        };
+
+        tests diag => sub {
+            my $ok = Test::Stream::Event::Ok->new(
+                debug => $dbg,
+                pass  => 0,
+                name  => 'the_test',
+                diag  => ['xxx'],
+            );
+
+            is(
+                [$fmt->event_tap($ok, 4)],
+                [
+                    [OUT_STD, "not ok 4 - the_test\n"],
+                    [OUT_ERR, "# xxx\n"],
+                ],
+                "Got tap for failing ok"
+            );
+        };
+    };
+
+    tests plan => sub {
+        my $plan = Test::Stream::Event::Plan->new(
+            debug => $dbg,
+            max => 100,
+        );
+
+        is(
+            [$fmt->event_tap($plan, 1)],
+            [[OUT_STD, "1..100\n"]],
+            "Got tap"
+        );
+
+        $plan->set_max(0);
+        $plan->set_directive('SKIP');
+        $plan->set_reason('foo');
+        is(
+            [$fmt->event_tap($plan, 1)],
+            [[OUT_STD, "1..0 # SKIP foo\n"]],
+            "Got tap for skip_all"
+        );
+
+        $plan = Test::Stream::Event::Plan->new(
+            debug => $dbg,
+            max => 0,
+            directive => 'skip_all',
+        );
+        is(
+            [$fmt->event_tap($plan)],
+            [[OUT_STD, "1..0 # SKIP\n"]],
+            "SKIP without reason"
+        );
+
+        $plan = Test::Stream::Event::Plan->new(
+            debug => $dbg,
+            max => 0,
+            directive => 'no_plan',
+        );
+        is(
+            [$fmt->event_tap($plan)],
+            [],
+            "NO PLAN"
+        );
+    };
+
+    tests subtest => sub {
+        my $st = 'Test::Stream::Event::Subtest';
+
+        my $one = $st->new(
+            debug     => $dbg,
+            pass      => 1,
+            buffered  => 1,
+            name      => 'foo',
+        );
+
+        is(
+            [$fmt->event_tap($one, 5)],
+            [
+                [OUT_STD, "ok 5 - foo {\n"],
+                [OUT_STD, "}\n"],
+            ],
+            "Got Buffered TAP output"
+        );
+
+        $one->set_buffered(0);
+        is(
+            [$fmt->event_tap($one, 5)],
+            [
+                [OUT_STD, "ok 5 - foo\n"],
+            ],
+            "Got Unbuffered TAP output"
+        );
+
+        $one = $st->new(
+            debug     => $dbg,
+            pass      => 0,
+            buffered  => 1,
+            name      => 'bar',
+            diag      => [ 'bar failed' ],
+            subevents => [
+                Test::Stream::Event::Ok->new(debug => $dbg, name => 'first',  pass => 1),
+                Test::Stream::Event::Ok->new(debug => $dbg, name => 'second', pass => 0, diag => ["second failed"]),
+                Test::Stream::Event::Ok->new(debug => $dbg, name => 'third',  pass => 1),
+
+                Test::Stream::Event::Diag->new(debug => $dbg, message => 'blah blah'),
+
+                Test::Stream::Event::Plan->new(debug => $dbg, max => 3),
+            ],
+        );
+
+        {
+            local $ENV{HARNESS_IS_VERBOSE};
+            is(
+                [$fmt->event_tap($one, 5)],
+                [
+                    [OUT_STD, "not ok 5 - bar {\n"],
+                    [OUT_ERR, "# bar failed\n"],
+                    [OUT_STD, "    ok 1 - first\n"],
+                    [OUT_STD, "    not ok 2 - second\n"],
+                    [OUT_ERR, "    # second failed\n"],
+                    [OUT_STD, "    ok 3 - third\n"],
+                    [OUT_ERR, "    # blah blah\n"],
+                    [OUT_STD, "    1..3\n"],
+                    [OUT_STD, "}\n"],
+                ],
+                "Got Buffered TAP output (non-verbose)"
+            );
+        }
+
+        {
+            local $ENV{HARNESS_IS_VERBOSE} = 1;
+            is(
+                [$fmt->event_tap($one, 5)],
+                [
+                    [OUT_STD, "not ok 5 - bar {\n"],
+                    [OUT_ERR, "    # bar failed\n"],
+                    [OUT_STD, "    ok 1 - first\n"],
+                    [OUT_STD, "    not ok 2 - second\n"],
+                    [OUT_ERR, "    # second failed\n"],
+                    [OUT_STD, "    ok 3 - third\n"],
+                    [OUT_ERR, "    # blah blah\n"],
+                    [OUT_STD, "    1..3\n"],
+                    [OUT_STD, "}\n"],
+                ],
+                "Got Buffered TAP output (verbose)"
+            );
+        }
+
+        {
+            local $ENV{HARNESS_IS_VERBOSE};
+            $one->set_buffered(0);
+            is(
+                [$fmt->event_tap($one, 5)],
+                [
+                    # In unbuffered TAP the subevents are rendered outside of this.
+                    [OUT_STD, "not ok 5 - bar\n"],
+                    [OUT_ERR, "# bar failed\n"],
+                ],
+                "Got Unbuffered TAP output (non-verbose)"
+            );
+        }
+
+        {
+            local $ENV{HARNESS_IS_VERBOSE} = 1;
+            $one->set_buffered(0);
+            is(
+                [$fmt->event_tap($one, 5)],
+                [
+                    # In unbuffered TAP the subevents are rendered outside of this.
+                    [OUT_STD, "not ok 5 - bar\n"],
+                    [OUT_ERR, "# bar failed\n"],
+                ],
+                "Got Unbuffered TAP output (verbose)"
+            );
+        }
+    };
+};
 
 done_testing;

--- a/t/modules/Formatter/TAP.t
+++ b/t/modules/Formatter/TAP.t
@@ -42,15 +42,18 @@ ok($layers->{utf8}, "Now utf8");
     use base 'Test::Stream::Event';
     use Test::Stream::HashBase accessors => [qw/pass name diag note/];
 
-    sub to_tap {
-        my $self = shift;
-        my ($num) = @_;
-        return (
-            [OUT_STD, "ok $num - " . $self->name . "\n"],
-            [OUT_ERR, "# " . $self->name . " " . $self->diag . "\n"],
-            [OUT_STD, "# " . $self->name . " " . $self->note . "\n"],
-        );
-    }
+    Test::Stream::Formatter::TAP->register_event(
+        __PACKAGE__,
+        sub {
+            my $self = shift;
+            my ($e, $num) = @_;
+            return (
+                [OUT_STD, "ok $num - " . $e->name . "\n"],
+                [OUT_ERR, "# " . $e->name . " " . $e->diag . "\n"],
+                [OUT_STD, "# " . $e->name . " " . $e->note . "\n"],
+            );
+        }
+    );
 }
 
 my ($std, $err);


### PR DESCRIPTION
* Move TAP logic from events to TAP formatter
* Port tests from events to the TAP formatter tests
* Maintain backcompat
* Deprecate to_tap
* Allow custom event support in TAP formatter
